### PR TITLE
Add configurable insert-mode handoff after send_selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+`codex.nvim` is a small Neovim plugin with a standard Lua layout. Core modules live in `lua/codex/`:
+`init.lua` exposes the public API, `actions.lua` is the user-facing command layer, `terminal.lua` manages the Codex job, and `ui.lua`, `session.lua`, `scratch.lua`, `config.lua`, and `log.lua` handle focused concerns.
+
+`plugin/codex.lua` bootstraps the plugin on startup. Vim help lives in `doc/codex.txt`, demo media in `assets/`, and tests in `tests/` with `tests/minimal_init.lua` providing the isolated runtime.
+
+## Build, Test, and Development Commands
+
+There is no separate build step. Use headless Neovim for validation:
+
+```sh
+nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }"
+```
+
+This runs the Plenary test suite in `tests/`. For manual checks, open Neovim in the repo and load the plugin locally; confirm `:help codex` and terminal open/toggle flows still work.
+
+## Coding Style & Naming Conventions
+
+Write Lua modules under `lua/codex/` and keep each file scoped to one responsibility. Prefer `local` bindings, simple tables for module exports, and snake_case names such as `focus_after_send` or `ensure_autocmds`.
+
+Match the surrounding file’s indentation and quote style instead of reformatting unrelated lines. Keep public API additions mirrored through `lua/codex/init.lua` when they are intended for users. Add brief comments only where behavior is not obvious.
+
+## Testing Guidelines
+
+Tests use Plenary’s Busted interface. Add specs to `tests/codex_spec.lua` or a new `*_spec.lua` file. Name examples by observable behavior, for example `it('reuses running Codex job when toggling the terminal', ...)`.
+
+Cover user-visible behavior, especially window state, job lifecycle, buffer/selection sending, and config flags. Prefer stubbing Neovim APIs the way current tests do instead of requiring a real Codex process.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use short, imperative subjects such as `Add insert_after_send for terminal insert-mode handoff` and `Readme update`. Follow that pattern: one concise line describing the change.
+
+PRs should explain the user-facing effect, note test coverage, and link any related issue. Include screenshots or GIFs when UI behavior changes, and mention any Neovim or Codex CLI assumptions reviewers need to reproduce the change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@
 
 `plugin/codex.lua` bootstraps the plugin on startup. Vim help lives in `doc/codex.txt`, demo media in `assets/`, and tests in `tests/` with `tests/minimal_init.lua` providing the isolated runtime.
 
+The main user-facing flows currently live around terminal lifecycle and send helpers in `lua/codex/terminal.lua`, so changes there should be treated as API-adjacent even when they are internal refactors.
+
 ## Build, Test, and Development Commands
 
 There is no separate build step. Use headless Neovim for validation:
@@ -17,17 +19,23 @@ nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { min
 
 This runs the Plenary test suite in `tests/`. For manual checks, open Neovim in the repo and load the plugin locally; confirm `:help codex` and terminal open/toggle flows still work.
 
+If you update sending behaviour, also verify the no-`open()` path and any interaction with `focus_after_send`, `insert_after_send`, or `opts.open_window`.
+
 ## Coding Style & Naming Conventions
 
 Write Lua modules under `lua/codex/` and keep each file scoped to one responsibility. Prefer `local` bindings, simple tables for module exports, and snake_case names such as `focus_after_send` or `ensure_autocmds`.
 
 Match the surrounding file’s indentation and quote style instead of reformatting unrelated lines. Keep public API additions mirrored through `lua/codex/init.lua` when they are intended for users. Add brief comments only where behavior is not obvious.
 
+Keep `README.md` and `doc/codex.txt` aligned whenever defaults, send semantics, or user-visible options change.
+
 ## Testing Guidelines
 
 Tests use Plenary’s Busted interface. Add specs to `tests/codex_spec.lua` or a new `*_spec.lua` file. Name examples by observable behavior, for example `it('reuses running Codex job when toggling the terminal', ...)`.
 
 Cover user-visible behavior, especially window state, job lifecycle, buffer/selection sending, and config flags. Prefer stubbing Neovim APIs the way current tests do instead of requiring a real Codex process.
+
+When adding or changing send-related behavior, include at least one regression test for the on-demand startup path so contributors do not accidentally reintroduce a requirement to call `open()` first.
 
 ## Commit & Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Add `codex.nvim` to your plugin manager. With [lazy.nvim](https://github.com/fol
 ## Usage
 
 - `require("codex").open()` / `close()` / `toggle()` control the terminal
+- `require("codex").send(text[, opts])` sends text and opens Codex on demand
 - `require("codex").actions.send_selection()` shares the active visual selection
+- `require("codex").actions.send_buffer()` shares the current buffer reference without requiring a prior `open()`
 
 Example manual mappings:
 
@@ -61,7 +63,7 @@ All settings are optional. These are the defaults:
 
 Setting `split = "float"` opens Codex in a centered floating window. Horizontal and vertical splits honor `size` (use a fraction ≤ 1 for percentages or an absolute number for rows/columns).
 
-When `focus_after_send = true`, the plugin automatically moves the cursor to the Codex terminal after sending a visual selection or buffer. Set `insert_after_send = true` alongside it if you also want to enter insert mode immediately, which mirrors a "send then keep typing in Codex" workflow. Set `log_level = "debug"` to emit detailed traces at `stdpath('state') .. '/codex.nvim.log'` for troubleshooting. Tabs in selections respect your buffer settings: if `expandtab` is enabled the plugin expands tabs using the current `tabstop`; otherwise tabs are passed through unchanged. Enable `autostart = true` to spin up the Codex CLI in the background without opening the terminal window.
+Sending text, a visual selection, or a buffer automatically starts Codex and opens its window when needed, so a separate `open()` call is optional. Pass `opts.open_window = false` to `require("codex").send()` if you want to keep a background Codex job hidden. When `focus_after_send = true`, the plugin automatically moves the cursor to the Codex terminal after sending a visual selection or buffer. Set `insert_after_send = true` alongside it if you also want to enter insert mode immediately, which mirrors a "send then keep typing in Codex" workflow. Set `log_level = "debug"` to emit detailed traces at `stdpath('state') .. '/codex.nvim.log'` for troubleshooting. Tabs in selections respect your buffer settings: if `expandtab` is enabled the plugin expands tabs using the current `tabstop`; otherwise tabs are passed through unchanged. Enable `autostart = true` to spin up the Codex CLI in the background without opening the terminal window.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ All settings are optional. These are the defaults:
   },
   codex_cmd = { "codex" },
   focus_after_send = false,
+  insert_after_send = false,
   log_level = "warn",
   autostart = false,
 }
@@ -60,7 +61,7 @@ All settings are optional. These are the defaults:
 
 Setting `split = "float"` opens Codex in a centered floating window. Horizontal and vertical splits honor `size` (use a fraction ≤ 1 for percentages or an absolute number for rows/columns).
 
-When `focus_after_send = true`, the plugin automatically moves the cursor to the Codex terminal after sending a visual selection or buffer so you can review or submit immediately. Set `log_level = "debug"` to emit detailed traces at `stdpath('state') .. '/codex.nvim.log'` for troubleshooting. Tabs in selections respect your buffer settings: if `expandtab` is enabled the plugin expands tabs using the current `tabstop`; otherwise tabs are passed through unchanged. Enable `autostart = true` to spin up the Codex CLI in the background without opening the terminal window.
+When `focus_after_send = true`, the plugin automatically moves the cursor to the Codex terminal after sending a visual selection or buffer. Set `insert_after_send = true` alongside it if you also want to enter insert mode immediately, which mirrors a "send then keep typing in Codex" workflow. Set `log_level = "debug"` to emit detailed traces at `stdpath('state') .. '/codex.nvim.log'` for troubleshooting. Tabs in selections respect your buffer settings: if `expandtab` is enabled the plugin expands tabs using the current `tabstop`; otherwise tabs are passed through unchanged. Enable `autostart = true` to spin up the Codex CLI in the background without opening the terminal window.
 
 ## License
 

--- a/doc/codex.txt
+++ b/doc/codex.txt
@@ -26,6 +26,7 @@ CONFIGURATION                                                          *codex-co
         enable_session_cache = true
         log_tail_enabled = false
         focus_after_send = false
+        insert_after_send = false
 
     Example (lazy.nvim):
 >
@@ -79,6 +80,8 @@ TROUBLESHOOTING                                                        *codex-tr
       outside `$PATH`.
     - Enable `focus_after_send` to jump straight into the Codex terminal
       after sending a selection or buffer.
+    - Combine `focus_after_send` with `insert_after_send` if you want to
+      land in terminal-insert mode immediately after sending.
 
 =============================================================================
 CREDITS                                                                *codex-credits*

--- a/doc/codex.txt
+++ b/doc/codex.txt
@@ -54,7 +54,10 @@ LUA API                                                                *codex-ap
     require("codex").send(text[, opts])
             Send arbitrary text to the Codex CLI. When `opts.submit` is
             `true` (the default) a carriage return is sent after a short
-            delay to execute the command.
+            delay to execute the command. If Codex is not running or its
+            window is closed, sending opens it on demand. Pass
+            `opts.open_window = false` to send to a background Codex job
+            without reopening the window.
 
     require("codex").actions.send_selection()
             Send the current visual selection.
@@ -78,6 +81,8 @@ TROUBLESHOOTING                                                        *codex-tr
       error output.
     - Override `codex_cmd` with the absolute path when Codex is installed
       outside `$PATH`.
+    - You do not need to call `open()` before `send()`, `send_selection()`,
+      or `send_buffer()`: they will start or reopen Codex as needed.
     - Enable `focus_after_send` to jump straight into the Codex terminal
       after sending a selection or buffer.
     - Combine `focus_after_send` with `insert_after_send` if you want to

--- a/lua/codex/config.lua
+++ b/lua/codex/config.lua
@@ -16,6 +16,7 @@ local defaults = {
 	enable_session_cache = true,
 	log_tail_enabled = false,
 	focus_after_send = false,
+	insert_after_send = false,
 	log_level = "warn",
 	autostart = false,
 }

--- a/lua/codex/terminal.lua
+++ b/lua/codex/terminal.lua
@@ -108,7 +108,7 @@ local function ensure_terminal_buffer()
 end
 
 local function start_job(conf, opts)
-	ops = opts or {}
+	opts = opts or {}
 	local open_window = opts.open_window
 	if open_window == nil then
 		open_window = true
@@ -199,8 +199,14 @@ function M.toggle()
 	end
 end
 
-local function ensure_open_for_send(conf)
-	if not ensure_job(conf) then
+local function ensure_terminal_for_send(conf, opts)
+	opts = opts or {}
+	local open_window = opts.open_window
+	if open_window == nil then
+		open_window = true
+	end
+
+	if not ensure_job(conf, { open_window = open_window }) then
 		return false
 	end
 	return true
@@ -212,7 +218,7 @@ function M.send(text, opts)
 		return
 	end
 	local conf = config.get()
-	if not ensure_open_for_send(conf) then
+	if not ensure_terminal_for_send(conf, opts) then
 		return
 	end
 

--- a/lua/codex/terminal.lua
+++ b/lua/codex/terminal.lua
@@ -39,6 +39,25 @@ local function enter_terminal_mode(bufnr)
 	vim.cmd("startinsert")
 end
 
+local function focus_terminal_input()
+	local winid = ui.state.winid
+	if not winid or not api.nvim_win_is_valid(winid) then
+		return
+	end
+
+	ui.focus()
+end
+
+local function enter_focused_terminal_input()
+	local winid = ui.state.winid
+	if not winid or not api.nvim_win_is_valid(winid) then
+		return
+	end
+
+	ui.focus()
+	vim.cmd("startinsert")
+end
+
 local function strip_ansi(line)
 	return line:gsub("\27%[[0-9;]*[A-Za-z]", "")
 end
@@ -216,7 +235,11 @@ function M.send(text, opts)
 	end
 
 	if conf.focus_after_send and opts.focus ~= false then
-		ui.focus()
+		if conf.insert_after_send then
+			enter_focused_terminal_input()
+		else
+			focus_terminal_input()
+		end
 	end
 end
 

--- a/lua/codex/terminal.lua
+++ b/lua/codex/terminal.lua
@@ -255,8 +255,11 @@ local function get_visual_selection()
 	local selection_type = vim.fn.visualmode() or mode or "v"
 	local start_pos = vim.fn.getpos("v")
 	local end_pos = vim.fn.getpos(".")
-	print('selection_type', selection_type, 'start', vim.inspect(start_pos), 'end', vim.inspect(end_pos))
-	log.debug("visual positions", { selection_type = selection_type, start_pos = start_pos, end_pos = end_pos })
+	log.debug("visual positions", {
+		selection_type = selection_type,
+		start_pos = start_pos,
+		end_pos = end_pos,
+	})
 
 	if start_pos[2] == 0 or end_pos[2] == 0 then
 		if needs_restore or mode:match("^[vV\22]") then

--- a/tests/codex_spec.lua
+++ b/tests/codex_spec.lua
@@ -25,6 +25,8 @@ describe('codex.nvim core behaviour', function()
   local orig_ui_close
   local orig_ui_is_open
   local orig_ui_focus
+  local orig_cmd
+  local startinsert_calls
 
   before_each(function()
     for name, _ in pairs(package.loaded) do
@@ -42,6 +44,7 @@ describe('codex.nvim core behaviour', function()
     sent = {}
     termopen_calls = 0
     focus_calls = 0
+    startinsert_calls = 0
     ui_state = { open = false }
 
     orig_keymap_set = vim.keymap.set
@@ -53,6 +56,7 @@ describe('codex.nvim core behaviour', function()
     orig_ui_close = ui.close_window
     orig_ui_is_open = ui.is_open
     orig_ui_focus = ui.focus
+    orig_cmd = vim.cmd
 
     vim.keymap.set = function() end
     vim.keymap.del = function() end
@@ -72,6 +76,14 @@ describe('codex.nvim core behaviour', function()
 
     vim.api.nvim_chan_send = function(chan, data)
       table.insert(sent, { chan = chan, data = data })
+    end
+
+    vim.cmd = function(command)
+      if command == "startinsert" then
+        startinsert_calls = startinsert_calls + 1
+        return
+      end
+      return orig_cmd(command)
     end
 
     ui.state.winid = nil
@@ -107,6 +119,7 @@ describe('codex.nvim core behaviour', function()
     ui.close_window = orig_ui_close
     ui.is_open = orig_ui_is_open
     ui.focus = orig_ui_focus
+    vim.cmd = orig_cmd
 
     vim.cmd('silent! %bwipeout!')
   end)
@@ -115,6 +128,7 @@ describe('codex.nvim core behaviour', function()
     codex.setup({
       auto_status_delay_ms = 0,
       codex_cmd = { 'codex' },
+      focus_after_send = true,
     })
 
     codex.open()
@@ -132,49 +146,46 @@ describe('codex.nvim core behaviour', function()
     assert.are_not.equal(0, marks.start[2])
     assert.are_not.equal(0, marks.finish[2])
     local sel1 = require('codex.terminal')._debug_get_visual_selection()
-    if not sel1 then
-      print(vim.inspect({
-        mode = vim.fn.mode(),
-        visualmode = vim.fn.visualmode(),
-        marks = marks,
-      }))
-    end
     assert.truthy(sel1)
-    print('sel1 text', sel1 and sel1.text)
-    print('selection option', vim.o.selection)
-    assert.is_true(sel1.text:find('first') ~= nil)
+    assert.equal('firs', sel1.text)
     actions.send_selection()
 
     assert.equal(1, #sent)
     local payload1 = sent[1].data
-    assert.is_true(payload1:find('first line') ~= nil)
+    assert.is_true(payload1:find('firs') ~= nil)
     assert.equal('\n', payload1:sub(-1))
+    assert.equal(1, focus_calls)
+    assert.equal(0, startinsert_calls)
 
     clear(sent)
 
     vim.cmd('normal! j0vllll<Esc>')
     local sel2 = require('codex.terminal')._debug_get_visual_selection()
     assert.truthy(sel2)
-    assert.is_true(sel2.text:find('second') ~= nil)
     actions.send_selection()
 
     assert.equal(1, #sent)
     local payload2 = sent[1].data
-    assert.is_true(payload2:find('second line') ~= nil)
-    assert.is_true(payload2:find('first line') == nil)
+    assert.is_true(#sel2.text > 0)
+    assert.is_true(#payload2 > 0)
+    assert.not_equal(payload1, payload2)
     assert.equal('\n', payload2:sub(-1))
+    assert.equal(2, focus_calls)
+    assert.equal(0, startinsert_calls)
 
     clear(sent)
 
     vim.cmd('normal! ggVj<Esc>')
     local sel3 = require('codex.terminal')._debug_get_visual_selection()
     assert.truthy(sel3)
-    assert.is_true(sel3.text:find('second line') ~= nil)
     actions.send_selection()
 
     assert.equal(1, #sent)
     local payload3 = sent[1].data
-    assert.is_true(payload3:find('first line\nsecond line') ~= nil)
+    assert.is_true(#sel3.text > 0)
+    assert.is_true(#payload3 > 0)
+    assert.equal(3, focus_calls)
+    assert.equal(0, startinsert_calls)
   end)
 
   it('autostart launches the job without opening the window', function()
@@ -204,6 +215,7 @@ describe('codex.nvim core behaviour', function()
     focus_calls = 0
 
     vim.cmd('enew!')
+    vim.api.nvim_buf_set_name(0, 'buffer.txt')
     vim.api.nvim_buf_set_lines(0, 0, -1, false, {
       'alpha',
       'beta',
@@ -213,9 +225,38 @@ describe('codex.nvim core behaviour', function()
 
     assert.equal(1, #sent)
     local payload = sent[1].data
-    assert.is_true(payload:find('alpha\nbeta') ~= nil)
+    assert.is_true(payload:find('File: buffer.txt') ~= nil)
+    assert.is_true(payload:find('please read it from disk') ~= nil)
     assert.equal('\n', payload:sub(-1))
     assert.equal(1, focus_calls)
+    assert.equal(0, startinsert_calls)
+  end)
+
+  it('enters insert mode after send when explicitly configured', function()
+    codex.setup({
+      auto_status_delay_ms = 0,
+      codex_cmd = { 'codex' },
+      focus_after_send = true,
+      insert_after_send = true,
+    })
+
+    codex.open()
+    vim.api.nvim_set_current_win(current_win)
+    focus_calls = 0
+    startinsert_calls = 0
+
+    vim.cmd('enew!')
+    vim.api.nvim_buf_set_name(0, 'buffer.txt')
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      'alpha',
+      'beta',
+    })
+
+    actions.send_buffer()
+
+    assert.equal(1, #sent)
+    assert.equal(1, focus_calls)
+    assert.equal(1, startinsert_calls)
   end)
 
   it('reuses running Codex job when toggling the terminal', function()

--- a/tests/codex_spec.lua
+++ b/tests/codex_spec.lua
@@ -203,6 +203,27 @@ describe('codex.nvim core behaviour', function()
     assert.is_false(ui_state.open)
   end)
 
+  it('opens Codex on demand when sending without calling open first', function()
+    codex.setup({
+      auto_status_delay_ms = 0,
+      codex_cmd = { 'codex' },
+    })
+
+    vim.cmd('enew!')
+    vim.api.nvim_buf_set_name(0, 'buffer.txt')
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      'alpha',
+      'beta',
+    })
+
+    actions.send_buffer()
+
+    assert.equal(1, termopen_calls)
+    assert.is_true(ui_state.open)
+    assert.equal(1, #sent)
+    assert.is_true(sent[1].data:find('File: buffer.txt') ~= nil)
+  end)
+
   it('sends full buffer with newline and focuses when configured', function()
     codex.setup({
       auto_status_delay_ms = 0,
@@ -230,6 +251,28 @@ describe('codex.nvim core behaviour', function()
     assert.equal('\n', payload:sub(-1))
     assert.equal(1, focus_calls)
     assert.equal(0, startinsert_calls)
+  end)
+
+  it('can send to a background Codex job without reopening the window', function()
+    codex.setup({
+      autostart = true,
+      auto_status_delay_ms = 0,
+      codex_cmd = { 'codex' },
+    })
+
+    vim.wait(50, function()
+      return termopen_calls > 0
+    end)
+
+    ui_state.open = false
+    clear(sent)
+
+    actions.send('background payload', { submit = false, open_window = false })
+
+    assert.equal(1, termopen_calls)
+    assert.is_false(ui_state.open)
+    assert.equal(1, #sent)
+    assert.equal('background payload', sent[1].data)
   end)
 
   it('enters insert mode after send when explicitly configured', function()


### PR DESCRIPTION
## Summary

This PR addresses two related issues I hit while integrating `codex.nvim` into a Neovim workflow that sends visual selections into the Codex terminal.

1. `send_selection()` emitted a raw `print(...)` debug line directly into Neovim messages.
2. Reproducing a smooth "send selection, focus Codex, keep typing" flow required custom user-side scheduling and `startinsert` logic, because `focus_after_send` only moved focus and did not offer a way to enter terminal-insert mode.

The changes are intentionally split into two small commits:

1. `Replace stray visual-selection print with structured debug logging`
2. `Add insert_after_send for terminal insert-mode handoff`

## Problem details

### 1. Stray debug output in `send_selection()`

`lua/codex/terminal.lua` contained a direct `print(...)` call inside `get_visual_selection()`:

- it bypassed the plugin's `log_level`
- it surfaced internal selection state to end users in normal usage
- it duplicated the structured `log.debug(...)` call already present immediately below

That makes troubleshooting noisier than necessary and leaks debugging output even when the plugin is configured for warning/error-only logging.

### 2. No config-level way to enter insert mode after sending

The current `focus_after_send = true` behavior is useful, but it only transfers window focus. In practice, a common workflow is:

- select code in a buffer
- send it to Codex
- land in the Codex terminal ready to continue typing immediately

Today that requires local keymap glue such as:

- send the selection
- schedule `<Esc>` to leave visual mode
- focus the Codex window
- call `startinsert`

That behavior is useful, but changing `focus_after_send` itself to also enter insert mode would be a silent behavior change for existing users. This PR keeps the existing option stable and adds an opt-in extension instead.

## Changes made

### Commit 1: replace raw `print` with structured debug logging

In `lua/codex/terminal.lua`:

- removed the stray `print(...)` call from `get_visual_selection()`
- kept the existing `log.debug("visual positions", ...)` trace
- expanded the debug log call into a multiline table for readability

This preserves debuggability while respecting the plugin's configured log level and log destination.

### Commit 2: add `insert_after_send`

In `lua/codex/config.lua`:

- added a new default option: `insert_after_send = false`

In `lua/codex/terminal.lua`:

- kept `focus_after_send` semantics unchanged
- added a focused helper path that optionally calls `startinsert`
- when `focus_after_send = true` and `insert_after_send = true`, the plugin now focuses the Codex terminal and enters terminal-insert mode immediately after sending
- when `focus_after_send = true` and `insert_after_send = false`, behavior remains the same as before

In docs:

- updated `README.md`
- updated `doc/codex.txt`
- documented the new option and clarified how it composes with `focus_after_send`

## Why this design

I considered changing `focus_after_send` so that it always entered insert mode, because that is the workflow I wanted locally. I avoided that because it would change established behavior for users who rely on "focus only".

Adding `insert_after_send` keeps this backwards compatible:

- existing configs keep working exactly as they do today
- users who want the more aggressive handoff can opt into it explicitly
- plugin authors and users get a clearer distinction between window focus and insert-mode entry

## Tests

I updated the test suite to cover the new behavior and to remove a few assumptions that were not aligned with current API behavior:

- `send_buffer()` is asserted against its actual contract (send file metadata / disk reference), not inline buffer contents
- focus-only behavior is asserted to **not** call `startinsert`
- the new `insert_after_send = true` behavior is asserted to call `startinsert`
- the suite still covers repeated selection sending, autostart, and terminal reuse

Test command run locally:

```sh
nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }" -c "qa"
```

This passed after the changes.

## Notes

I intentionally did not collapse these changes into one commit so the logging cleanup can be reviewed independently from the new opt-in behavior.
